### PR TITLE
Dupedetect

### DIFF
--- a/pkg/match/inverse.go
+++ b/pkg/match/inverse.go
@@ -14,11 +14,11 @@ var (
 var capThreshold = 4
 
 type ResetT struct {
-	Term     string // Inverse term
-	Window   int64  // Window size; defaults to 0 which in combination with !Absolute means the window is the range of the matched sequence.
-	Slide    int64  // Slide the anchor, +/- relative to the anchor term
-	Anchor   uint8  // Anchor term; defaults to first event in match sequence
-	Absolute bool   // Absolute window time or relative to the range of the matched sequence.
+	Term     TermT // Inverse term
+	Window   int64 // Window size; defaults to 0 which in combination with !Absolute means the window is the range of the matched sequence.
+	Slide    int64 // Slide the anchor, +/- relative to the anchor term
+	Anchor   uint8 // Anchor term; defaults to first event in match sequence
+	Absolute bool  // Absolute window time or relative to the range of the matched sequence.
 }
 
 type resetT struct {

--- a/pkg/match/inverse_seq.go
+++ b/pkg/match/inverse_seq.go
@@ -20,12 +20,12 @@ type InverseSeq struct {
 	resets   []resetT
 }
 
-func NewInverseSeq(window int64, seqTerms []string, resetTerms []ResetT) (*InverseSeq, error) {
+func NewInverseSeq(window int64, seqTerms []TermT, resetTerms []ResetT) (*InverseSeq, error) {
 
 	var (
 		resets   []resetT
 		terms    = make([]termT, 0, len(seqTerms))
-		dupes    = make(map[string]int, len(seqTerms))
+		dupes    = make(map[TermT]int, len(seqTerms))
 		dupeMask bitMaskT
 	)
 
@@ -47,7 +47,7 @@ func NewInverseSeq(window int64, seqTerms []string, resetTerms []ResetT) (*Inver
 	}
 
 	for i, term := range seqTerms {
-		m, err := makeMatchFunc(term)
+		m, err := term.NewMatcher()
 		if err != nil {
 			return nil, err
 		}
@@ -61,7 +61,7 @@ func NewInverseSeq(window int64, seqTerms []string, resetTerms []ResetT) (*Inver
 		resets = make([]resetT, 0, len(resetTerms))
 
 		for _, term := range resetTerms {
-			m, err := makeMatchFunc(term.Term)
+			m, err := term.Term.NewMatcher()
 			switch {
 			case err != nil:
 				return nil, err

--- a/pkg/match/inverse_seq_test.go
+++ b/pkg/match/inverse_seq_test.go
@@ -21,13 +21,13 @@ func TestSeqInverseBadReset(t *testing.T) {
 
 		resets = []ResetT{
 			{
-				Term:   "Shutdown initiated",
+				Term:   makeRaw("Shutdown initiated"),
 				Anchor: 11, // Bad anchor
 			},
 		}
 	)
 
-	_, err := NewInverseSeq(window, []string{"alpha", "beta"}, resets)
+	_, err := NewInverseSeq(window, makeTermsA("alpha", "beta"), resets)
 	if err != ErrAnchorRange {
 		t.Fatalf("Expected err == ErrAnchorRange, got %v", err)
 	}
@@ -59,7 +59,7 @@ func TestSeqInverse(t *testing.T) {
 			reset: []ResetT{
 				{
 					Window: 10,
-					Term:   "reset",
+					Term:   makeRaw("reset"),
 				},
 			},
 			steps: []step{
@@ -76,7 +76,7 @@ func TestSeqInverse(t *testing.T) {
 			reset: []ResetT{
 				{
 					Window: 10,
-					Term:   "reset",
+					Term:   makeRaw("reset"),
 				},
 			},
 			steps: []step{
@@ -93,7 +93,7 @@ func TestSeqInverse(t *testing.T) {
 			window: 10,
 			terms:  []string{"alpha"},
 			reset: []ResetT{{
-				Term: "reset",
+				Term: makeRaw("reset"),
 			}}, // Simple relative reset
 			steps: []step{
 				{line: "alpha", stamp: 1},
@@ -123,7 +123,7 @@ func TestSeqInverse(t *testing.T) {
 			window: 10,
 			terms:  []string{"alpha", "beta"},
 			reset: []ResetT{{
-				Term: "reset",
+				Term: makeRaw("reset"),
 			}}, // Simple relative reset
 			steps: []step{
 				{line: "alpha", stamp: 1},
@@ -140,7 +140,7 @@ func TestSeqInverse(t *testing.T) {
 			terms:  []string{"alpha", "beta"},
 			reset: []ResetT{
 				{
-					Term:     "reset",
+					Term:     makeRaw("reset"),
 					Window:   50,
 					Absolute: true,
 				},
@@ -161,7 +161,7 @@ func TestSeqInverse(t *testing.T) {
 			terms:  []string{"alpha", "beta"},
 			reset: []ResetT{
 				{
-					Term:     "reset",
+					Term:     makeRaw("reset"),
 					Window:   50,
 					Absolute: true,
 				},
@@ -181,7 +181,7 @@ func TestSeqInverse(t *testing.T) {
 			terms:  []string{"alpha", "beta"},
 			reset: []ResetT{
 				{
-					Term:     "reset",
+					Term:     makeRaw("reset"),
 					Window:   50,
 					Absolute: true,
 				},
@@ -216,7 +216,7 @@ func TestSeqInverse(t *testing.T) {
 			terms:  []string{"alpha", "beta"},
 			reset: []ResetT{
 				{
-					Term:     "reset",
+					Term:     makeRaw("reset"),
 					Slide:    -5,
 					Window:   20,
 					Absolute: true,
@@ -242,7 +242,7 @@ func TestSeqInverse(t *testing.T) {
 			terms:  []string{"alpha", "beta"},
 			reset: []ResetT{
 				{
-					Term:     "reset",
+					Term:     makeRaw("reset"),
 					Slide:    5,
 					Window:   20,
 					Absolute: true,
@@ -271,7 +271,7 @@ func TestSeqInverse(t *testing.T) {
 			terms:  []string{"alpha", "beta", "gamma"},
 			reset: []ResetT{
 				{
-					Term:   "reset",
+					Term:   makeRaw("reset"),
 					Window: 10,
 				},
 			},
@@ -292,7 +292,7 @@ func TestSeqInverse(t *testing.T) {
 			terms:  []string{"alpha", "beta"},
 			reset: []ResetT{
 				{
-					Term:     "reset",
+					Term:     makeRaw("reset"),
 					Window:   10,
 					Absolute: true,
 					Anchor:   1,
@@ -317,7 +317,7 @@ func TestSeqInverse(t *testing.T) {
 			terms:  []string{"alpha", "beta", "gamma"},
 			reset: []ResetT{
 				{
-					Term:     "reset",
+					Term:     makeRaw("reset"),
 					Window:   5,
 					Absolute: true,
 					Anchor:   2,
@@ -343,8 +343,8 @@ func TestSeqInverse(t *testing.T) {
 			window: 50,
 			terms:  []string{"alpha", "beta"},
 			reset: []ResetT{
-				{Term: "reset1"},
-				{Term: "reset2"},
+				{Term: makeRaw("reset1")},
+				{Term: makeRaw("reset2")},
 			},
 			steps: []step{
 				{line: "alpha"},
@@ -367,10 +367,10 @@ func TestSeqInverse(t *testing.T) {
 			window: 50,
 			terms:  []string{"alpha", "beta"},
 			reset: []ResetT{
-				{Term: "reset1"},
-				{Term: "reset2"},
+				{Term: makeRaw("reset1")},
+				{Term: makeRaw("reset2")},
 				{
-					Term:     "reset3",
+					Term:     makeRaw("reset3"),
 					Window:   100,
 					Absolute: true,
 				},
@@ -387,10 +387,10 @@ func TestSeqInverse(t *testing.T) {
 			window: 50,
 			terms:  []string{"alpha", "beta"},
 			reset: []ResetT{
-				{Term: "reset1"},
-				{Term: "reset2"},
+				{Term: makeRaw("reset1")},
+				{Term: makeRaw("reset2")},
 				{
-					Term:     "reset3",
+					Term:     makeRaw("reset3"),
 					Window:   100,
 					Absolute: true,
 				},
@@ -408,7 +408,7 @@ func TestSeqInverse(t *testing.T) {
 			terms:  []string{"alpha", "beta"},
 			reset: []ResetT{
 				{
-					Term:     "reset",
+					Term:     makeRaw("reset"),
 					Window:   20,
 					Absolute: true,
 				},
@@ -426,10 +426,10 @@ func TestSeqInverse(t *testing.T) {
 			window: 10,
 			terms:  []string{"alpha", "beta"},
 			reset: []ResetT{
-				{Term: "reset1"},
-				{Term: "reset2"},
+				{Term: makeRaw("reset1")},
+				{Term: makeRaw("reset2")},
 				{
-					Term:     "reset3",
+					Term:     makeRaw("reset3"),
 					Absolute: false,
 					Window:   5,
 				},
@@ -485,7 +485,7 @@ func TestSeqInverse(t *testing.T) {
 			},
 			reset: []ResetT{
 				{
-					Term:     "reset",
+					Term:     makeRaw("reset"),
 					Window:   20,
 					Absolute: true,
 				},
@@ -516,7 +516,7 @@ func TestSeqInverse(t *testing.T) {
 			},
 			reset: []ResetT{
 				{
-					Term:     "reset",
+					Term:     makeRaw("reset"),
 					Window:   20,
 					Absolute: true,
 				},
@@ -560,7 +560,7 @@ func TestSeqInverse(t *testing.T) {
 		"ResetsIgnoreOnNoMatch": {
 			window: 10,
 			terms:  []string{"alpha", "beta", "gamma"},
-			reset:  []ResetT{{Term: "reset"}},
+			reset:  []ResetT{{Term: makeRaw("reset")}},
 			steps: []step{
 				{line: "reset"},
 				{line: "reset"},
@@ -574,7 +574,7 @@ func TestSeqInverse(t *testing.T) {
 			terms:  []string{"alpha", "beta", "gamma"},
 			reset: []ResetT{
 				{
-					Term:   "reset",
+					Term:   makeRaw("reset"),
 					Slide:  -10,
 					Window: 20,
 				},
@@ -745,7 +745,7 @@ func TestSeqInverse(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			sm, err := NewInverseSeq(tc.window, tc.terms, tc.reset)
+			sm, err := NewInverseSeq(tc.window, makeTerms(tc.terms), tc.reset)
 			if err != nil {
 				t.Fatalf("Expected err == nil, got %v", err)
 			}
@@ -785,7 +785,7 @@ func TestSeqInverse(t *testing.T) {
 // --------------------
 
 func BenchmarkSeqInverseMisses(b *testing.B) {
-	sm, err := NewInverseSeq(int64(time.Second), []string{"frank", "burns"}, nil)
+	sm, err := NewInverseSeq(int64(time.Second), makeTermsA("frank", "burns"), nil)
 	if err != nil {
 		b.Fatalf("Expected err == nil, got %v", err)
 	}
@@ -803,13 +803,13 @@ func BenchmarkSeqInverseMissesWithReset(b *testing.B) {
 
 	resets := []ResetT{
 		{
-			Term:     "badterm",
+			Term:     makeRaw("badterm"),
 			Window:   1000,
 			Absolute: true,
 		},
 	}
 
-	sm, err := NewInverseSeq(int64(time.Second), []string{"frank", "burns"}, resets)
+	sm, err := NewInverseSeq(int64(time.Second), makeTermsA("frank", "burns"), resets)
 	if err != nil {
 		b.Fatalf("Expected err == nil, got %v", err)
 	}
@@ -828,7 +828,7 @@ func BenchmarkSeqInverseHitSequence(b *testing.B) {
 	zerolog.SetGlobalLevel(zerolog.Disabled)
 	defer zerolog.SetGlobalLevel(level)
 
-	sm, err := NewInverseSeq(int64(time.Second), []string{"frank", "burns"}, nil)
+	sm, err := NewInverseSeq(int64(time.Second), makeTermsA("frank", "burns"), nil)
 	if err != nil {
 		b.Fatalf("Expected err == nil, got %v", err)
 	}
@@ -855,7 +855,7 @@ func BenchmarkSeqInverseHitOverlap(b *testing.B) {
 	zerolog.SetGlobalLevel(zerolog.Disabled)
 	defer zerolog.SetGlobalLevel(level)
 
-	sm, err := NewInverseSeq(10, []string{"frank", "burns"}, nil)
+	sm, err := NewInverseSeq(10, makeTermsA("frank", "burns"), nil)
 	if err != nil {
 		b.Fatalf("Expected err == nil, got %v", err)
 	}
@@ -891,7 +891,7 @@ func BenchmarkSeqInverseRunawayMatch(b *testing.B) {
 	zerolog.SetGlobalLevel(zerolog.Disabled)
 	defer zerolog.SetGlobalLevel(level)
 
-	sm, err := NewInverseSeq(1000000, []string{"frank", "burns"}, nil)
+	sm, err := NewInverseSeq(1000000, makeTermsA("frank", "burns"), nil)
 	if err != nil {
 		b.Fatalf("Expected err == nil, got %v", err)
 	}

--- a/pkg/match/inverse_set.go
+++ b/pkg/match/inverse_set.go
@@ -19,7 +19,7 @@ type InverseSet struct {
 	resets  []resetT
 }
 
-func NewInverseSet(window int64, setTerms []string, resetTerms []ResetT) (*InverseSet, error) {
+func NewInverseSet(window int64, setTerms []TermT, resetTerms []ResetT) (*InverseSet, error) {
 
 	if len(setTerms) > 64 {
 		return nil, ErrTooManyTerms
@@ -30,12 +30,12 @@ func NewInverseSet(window int64, setTerms []string, resetTerms []ResetT) (*Inver
 
 	var (
 		resets []resetT
-		dupes  = make(map[string]struct{})
+		dupes  = make(map[TermT]struct{})
 		terms  = make([]termT, 0, len(setTerms))
 	)
 
 	for _, term := range setTerms {
-		m, err := makeMatchFunc(term)
+		m, err := term.NewMatcher()
 		if err != nil {
 			return nil, err
 		}
@@ -50,7 +50,7 @@ func NewInverseSet(window int64, setTerms []string, resetTerms []ResetT) (*Inver
 		resets = make([]resetT, 0, len(resetTerms))
 
 		for _, term := range resetTerms {
-			m, err := makeMatchFunc(term.Term)
+			m, err := term.Term.NewMatcher()
 			switch {
 			case err != nil:
 				return nil, err

--- a/pkg/match/inverse_set_test.go
+++ b/pkg/match/inverse_set_test.go
@@ -34,7 +34,7 @@ func TestSetInverse(t *testing.T) {
 			reset: []ResetT{
 				{
 					Window: 10,
-					Term:   "reset",
+					Term:   makeRaw("reset"),
 				},
 			},
 			steps: []step{
@@ -51,7 +51,7 @@ func TestSetInverse(t *testing.T) {
 			reset: []ResetT{
 				{
 					Window: 10,
-					Term:   "reset",
+					Term:   makeRaw("reset"),
 				},
 			},
 			steps: []step{
@@ -68,7 +68,7 @@ func TestSetInverse(t *testing.T) {
 			window: 10,
 			terms:  []string{"alpha"},
 			reset: []ResetT{{
-				Term: "reset",
+				Term: makeRaw("reset"),
 			}}, // Simple relative reset
 			steps: []step{
 				{line: "alpha", stamp: 1},
@@ -133,7 +133,7 @@ func TestSetInverse(t *testing.T) {
 			window: 10,
 			terms:  []string{"alpha", "beta"},
 			reset: []ResetT{{
-				Term: "reset",
+				Term: makeRaw("reset"),
 			}}, // Simple relative reset
 			steps: []step{
 				{line: "alpha", stamp: 1},
@@ -152,7 +152,7 @@ func TestSetInverse(t *testing.T) {
 			terms:  []string{"alpha", "beta"},
 			reset: []ResetT{
 				{
-					Term:     "Shutdown initiated",
+					Term:     makeRaw("Shutdown initiated"),
 					Window:   20,
 					Absolute: true,
 				},
@@ -175,7 +175,7 @@ func TestSetInverse(t *testing.T) {
 			terms:  []string{"alpha", "beta"},
 			reset: []ResetT{
 				{
-					Term:     "reset",
+					Term:     makeRaw("reset"),
 					Slide:    -5,
 					Window:   5,
 					Absolute: true,
@@ -199,7 +199,7 @@ func TestSetInverse(t *testing.T) {
 			terms:  []string{"alpha", "beta"},
 			reset: []ResetT{
 				{
-					Term:     "reset",
+					Term:     makeRaw("reset"),
 					Slide:    20,
 					Window:   15,
 					Absolute: true,
@@ -226,7 +226,7 @@ func TestSetInverse(t *testing.T) {
 			terms:  []string{"alpha", "beta", "gamma"},
 			reset: []ResetT{
 				{
-					Term:   "reset",
+					Term:   makeRaw("reset"),
 					Window: 10,
 				},
 			},
@@ -244,7 +244,7 @@ func TestSetInverse(t *testing.T) {
 			terms:  []string{"alpha", "beta"},
 			reset: []ResetT{
 				{
-					Term:     "reset",
+					Term:     makeRaw("reset"),
 					Window:   60,
 					Absolute: true,
 					Anchor:   1, // Anchor on beta
@@ -264,7 +264,7 @@ func TestSetInverse(t *testing.T) {
 			terms:  []string{"alpha", "beta"},
 			reset: []ResetT{
 				{
-					Term:     "reset",
+					Term:     makeRaw("reset"),
 					Window:   60,
 					Absolute: true,
 					Anchor:   1, // Anchor on beta
@@ -285,7 +285,7 @@ func TestSetInverse(t *testing.T) {
 			terms:  []string{"alpha", "beta"},
 			reset: []ResetT{
 				{
-					Term:     "reset",
+					Term:     makeRaw("reset"),
 					Window:   60,
 					Absolute: true,
 					Anchor:   1, // Anchor on beta
@@ -306,7 +306,7 @@ func TestSetInverse(t *testing.T) {
 			terms:  []string{"alpha", "beta"},
 			reset: []ResetT{
 				{
-					Term:     "reset",
+					Term:     makeRaw("reset"),
 					Window:   60,
 					Absolute: true,
 					Anchor:   1, // Anchor on beta
@@ -333,7 +333,7 @@ func TestSetInverse(t *testing.T) {
 			terms:  []string{"alpha", "beta", "gamma"},
 			reset: []ResetT{
 				{
-					Term:     "reset",
+					Term:     makeRaw("reset"),
 					Window:   5,
 					Absolute: true,
 					Anchor:   2,
@@ -361,8 +361,8 @@ func TestSetInverse(t *testing.T) {
 			window: 50,
 			terms:  []string{"alpha", "beta"},
 			reset: []ResetT{
-				{Term: "reset1"},
-				{Term: "reset2"},
+				{Term: makeRaw("reset1")},
+				{Term: makeRaw("reset2")},
 			},
 			steps: []step{
 				{line: "Match alpha."},
@@ -390,10 +390,10 @@ func TestSetInverse(t *testing.T) {
 			window: 50,
 			terms:  []string{"alpha", "beta"},
 			reset: []ResetT{
-				{Term: "reset1"},
-				{Term: "reset2"},
+				{Term: makeRaw("reset1")},
+				{Term: makeRaw("reset2")},
 				{
-					Term:     "reset3",
+					Term:     makeRaw("reset3"),
 					Absolute: true,
 					Window:   1000,
 				},
@@ -418,10 +418,10 @@ func TestSetInverse(t *testing.T) {
 			window: 50,
 			terms:  []string{"alpha", "beta"},
 			reset: []ResetT{
-				{Term: "reset1"},
-				{Term: "reset2"},
+				{Term: makeRaw("reset1")},
+				{Term: makeRaw("reset2")},
 				{
-					Term:     "reset3",
+					Term:     makeRaw("reset3"),
 					Absolute: true,
 					Window:   1000,
 				},
@@ -445,10 +445,10 @@ func TestSetInverse(t *testing.T) {
 			window: 10,
 			terms:  []string{"alpha", "beta"},
 			reset: []ResetT{
-				{Term: "reset1"},
-				{Term: "reset2"},
+				{Term: makeRaw("reset1")},
+				{Term: makeRaw("reset2")},
 				{
-					Term:     "reset3",
+					Term:     makeRaw("reset3"),
 					Absolute: false,
 					Window:   30,
 				},
@@ -496,7 +496,7 @@ func TestSetInverse(t *testing.T) {
 			window: 10,
 			terms:  []string{"alpha", "beta", "gamma"},
 			reset: []ResetT{
-				{Term: "reset"},
+				{Term: makeRaw("reset")},
 			},
 			steps: []step{
 				{line: "reset"},
@@ -516,7 +516,7 @@ func TestSetInverse(t *testing.T) {
 			terms:  []string{"alpha", "beta"},
 			reset: []ResetT{
 				{
-					Term:   "reset",
+					Term:   makeRaw("reset"),
 					Slide:  -10,
 					Window: 20,
 				},
@@ -552,7 +552,7 @@ func TestSetInverse(t *testing.T) {
 			terms:  []string{"alpha", "beta"},
 			reset: []ResetT{
 				{
-					Term:     "reset",
+					Term:     makeRaw("reset"),
 					Window:   50,
 					Absolute: true,
 				},
@@ -567,7 +567,7 @@ func TestSetInverse(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			sm, err := NewInverseSet(tc.window, tc.terms, tc.reset)
+			sm, err := NewInverseSet(tc.window, makeTerms(tc.terms), tc.reset)
 			if err != nil {
 				t.Fatalf("Expected err == nil, got %v", err)
 			}
@@ -610,13 +610,13 @@ func TestSetInverseBadAnchor(t *testing.T) {
 
 		resets = []ResetT{
 			{
-				Term:   "Shutdown initiated",
+				Term:   makeRaw("Shutdown initiated"),
 				Anchor: 11, // Bad anchor
 			},
 		}
 	)
 
-	_, err := NewInverseSet(window, []string{"alpha", "beta"}, resets)
+	_, err := NewInverseSet(window, makeTermsA("alpha", "beta"), resets)
 	if err != ErrAnchorRange {
 		t.Fatalf("Expected err == ErrAnchorRange, got %v", err)
 	}
@@ -625,7 +625,7 @@ func TestSetInverseBadAnchor(t *testing.T) {
 // Dupes not yet implemented.
 func TestSetInverseDupes(t *testing.T) {
 
-	_, err := NewInverseSet(10, []string{"alpha", "alpha"}, nil)
+	_, err := NewInverseSet(10, makeTermsA("alpha", "alpha"), nil)
 	if err != ErrDuplicateTerm {
 		t.Fatalf("Expected err == ErrDuplicateTerm, got %v", err)
 	}
@@ -634,7 +634,7 @@ func TestSetInverseDupes(t *testing.T) {
 // --------------------
 
 func BenchmarkSetInverseMisses(b *testing.B) {
-	sm, err := NewInverseSet(int64(time.Second), []string{"frank", "burns"}, nil)
+	sm, err := NewInverseSet(int64(time.Second), makeTermsA("frank", "burns"), nil)
 	if err != nil {
 		b.Fatalf("Expected err == nil, got %v", err)
 	}
@@ -652,13 +652,13 @@ func BenchmarkSetInverseMissesWithReset(b *testing.B) {
 
 	resets := []ResetT{
 		{
-			Term:     "badterm",
+			Term:     makeRaw("badterm"),
 			Window:   1000,
 			Absolute: true,
 		},
 	}
 
-	sm, err := NewInverseSet(int64(time.Second), []string{"frank", "burns"}, resets)
+	sm, err := NewInverseSet(int64(time.Second), makeTermsA("frank", "burns"), resets)
 	if err != nil {
 		b.Fatalf("Expected err == nil, got %v", err)
 	}
@@ -677,7 +677,7 @@ func BenchmarkSetInverseHitSequence(b *testing.B) {
 	zerolog.SetGlobalLevel(zerolog.Disabled)
 	defer zerolog.SetGlobalLevel(level)
 
-	sm, err := NewInverseSet(int64(time.Second), []string{"frank", "burns"}, nil)
+	sm, err := NewInverseSet(int64(time.Second), makeTermsA("frank", "burns"), nil)
 	if err != nil {
 		b.Fatalf("Expected err == nil, got %v", err)
 	}
@@ -704,7 +704,7 @@ func BenchmarkSetInverseHitOverlap(b *testing.B) {
 	zerolog.SetGlobalLevel(zerolog.Disabled)
 	defer zerolog.SetGlobalLevel(level)
 
-	sm, err := NewInverseSet(10, []string{"frank", "burns"}, nil)
+	sm, err := NewInverseSet(10, makeTermsA("frank", "burns"), nil)
 	if err != nil {
 		b.Fatalf("Expected err == nil, got %v", err)
 	}
@@ -740,7 +740,7 @@ func BenchmarkSetInverseRunawayMatch(b *testing.B) {
 	zerolog.SetGlobalLevel(zerolog.Disabled)
 	defer zerolog.SetGlobalLevel(level)
 
-	sm, err := NewInverseSet(1000000, []string{"frank", "burns"}, nil)
+	sm, err := NewInverseSet(1000000, makeTermsA("frank", "burns"), nil)
 	if err != nil {
 		b.Fatalf("Expected err == nil, got %v", err)
 	}

--- a/pkg/match/inverse_test.go
+++ b/pkg/match/inverse_test.go
@@ -152,3 +152,18 @@ func garbageCollect[T Matcher](clock int64) func(*testing.T, int, T) {
 		sm.GarbageCollect(clock)
 	}
 }
+
+func makeTerms(terms []string) []TermT {
+	out := make([]TermT, 0, len(terms))
+	for _, term := range terms {
+		out = append(out, TermT{Type: TermRaw, Value: term})
+	}
+	return out
+}
+func makeTermsA(terms ...string) []TermT {
+	return makeTerms(terms)
+}
+
+func makeRaw(term string) TermT {
+	return TermT{Type: TermRaw, Value: term}
+}

--- a/pkg/match/match_test.go
+++ b/pkg/match/match_test.go
@@ -6,7 +6,12 @@ import (
 
 func TestMatchJson(t *testing.T) {
 
-	m, err := makeMatchFunc("jq_json:.shrubbery")
+	tt := TermT{
+		Type:  TermJqJson,
+		Value: `select(.shrubbery == "apple")`,
+	}
+
+	m, err := tt.NewMatcher()
 	if err != nil {
 		t.Fatalf("Expected nil error, got: %v", err)
 	}
@@ -23,8 +28,12 @@ func TestMatchJson(t *testing.T) {
 }
 
 func TestMatchJsonString(t *testing.T) {
+	tt := TermT{
+		Type:  TermJqJson,
+		Value: `select(.shrubbery == "apple")`,
+	}
 
-	m, err := makeMatchFunc(`jq_json:select(.shrubbery == "apple")`)
+	m, err := tt.NewMatcher()
 	if err != nil {
 		t.Fatalf("Expected nil error, got: %v", err)
 	}
@@ -42,8 +51,12 @@ func TestMatchJsonString(t *testing.T) {
 }
 
 func TestMatchJsonRegex(t *testing.T) {
+	tt := TermT{
+		Type:  TermJqJson,
+		Value: `.shrubbery | test("^a.")`,
+	}
 
-	m, err := makeMatchFunc(`jq_json:.shrubbery | test("^a.")`)
+	m, err := tt.NewMatcher()
 	if err != nil {
 		t.Fatalf("Expected nil error, got: %v", err)
 	}
@@ -64,8 +77,12 @@ func TestMatchJsonRegex(t *testing.T) {
 }
 
 func TestMatchYaml(t *testing.T) {
+	tt := TermT{
+		Type:  TermJqYaml,
+		Value: `.shrubbery`,
+	}
 
-	m, err := makeMatchFunc("jq_yaml:.shrubbery")
+	m, err := tt.NewMatcher()
 	if err != nil {
 		t.Fatalf("Expected nil error, got: %v", err)
 	}
@@ -109,10 +126,24 @@ var jsonData = `
 } `
 
 func BenchmarkMatchJson(b *testing.B) {
+	var (
+		tt1 = TermT{
+			Type:  TermJqJson,
+			Value: `.widget.window.name`,
+		}
+		tt2 = TermT{
+			Type:  TermJqJson,
+			Value: `.widget.image.hOffset`,
+		}
+		tt3 = TermT{
+			Type:  TermJqJson,
+			Value: `.widget.text.onMouseUp`,
+		}
 
-	m1, _ := makeMatchFunc("jq_json:.widget.window.name")
-	m2, _ := makeMatchFunc("jq_json:.widget.image.hOffset")
-	m3, _ := makeMatchFunc("jq_json:.widget.text.onMouseUp")
+		m1, _ = tt1.NewMatcher()
+		m2, _ = tt2.NewMatcher()
+		m3, _ = tt3.NewMatcher()
+	)
 
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {

--- a/pkg/match/seq.go
+++ b/pkg/match/seq.go
@@ -25,11 +25,11 @@ type MatchSeq struct {
 	terms    []termT
 }
 
-func NewMatchSeq(window int64, terms ...string) (*MatchSeq, error) {
+func NewMatchSeq(window int64, terms ...TermT) (*MatchSeq, error) {
 	var (
 		nTerms   = len(terms)
 		termL    = make([]termT, nTerms)
-		dupes    = make(map[string]int, nTerms)
+		dupes    = make(map[TermT]int, nTerms)
 		dupeMask bitMaskT
 	)
 
@@ -51,7 +51,7 @@ func NewMatchSeq(window int64, terms ...string) (*MatchSeq, error) {
 	}
 
 	for i, term := range terms {
-		if m, err := makeMatchFunc(term); err != nil {
+		if m, err := term.NewMatcher(); err != nil {
 			return nil, err
 		} else {
 			termL[i].matcher = m

--- a/pkg/match/seq_test.go
+++ b/pkg/match/seq_test.go
@@ -323,7 +323,7 @@ func TestSeq(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			sm, err := NewMatchSeq(tc.window, tc.terms...)
+			sm, err := NewMatchSeq(tc.window, makeTerms(tc.terms)...)
 			if err != nil {
 				t.Fatalf("Expected err == nil, got %v", err)
 			}
@@ -363,7 +363,7 @@ func TestSeq(t *testing.T) {
 // ----------
 
 func BenchmarkSequenceMisses(b *testing.B) {
-	sm, err := NewMatchSeq(int64(time.Second), "frank", "burns")
+	sm, err := NewMatchSeq(int64(time.Second), makeTermsA("frank", "burns")...)
 	if err != nil {
 		b.Fatalf("Expected err == nil, got %v", err)
 	}
@@ -384,7 +384,7 @@ func TestSeqTimestampOutofOrder(t *testing.T) {
 		window int64 = 10
 	)
 
-	sm, err := NewMatchSeq(window, "alpha", "gamma")
+	sm, err := NewMatchSeq(window, makeTermsA("alpha", "gamma")...)
 	if err != nil {
 		t.Fatalf("Expected err == nil, got %v", err)
 	}
@@ -410,7 +410,7 @@ func TestSeqDupeTimestamps(t *testing.T) {
 		window int64 = 10
 	)
 
-	sm, err := NewMatchSeq(window, "alpha", "gamma")
+	sm, err := NewMatchSeq(window, makeTermsA("alpha", "gamma")...)
 	if err != nil {
 		t.Fatalf("Expected err == nil, got %v", err)
 	}
@@ -465,7 +465,7 @@ func expectCleanState(t *testing.T, sm *MatchSeq) {
 }
 
 func BenchmarkSequenceHitSequence(b *testing.B) {
-	sm, err := NewMatchSeq(int64(time.Second), "frank", "burns")
+	sm, err := NewMatchSeq(int64(time.Second), makeTermsA("frank", "burns")...)
 	if err != nil {
 		b.Fatalf("Expected err == nil, got %v", err)
 	}
@@ -488,7 +488,7 @@ func BenchmarkSequenceHitSequence(b *testing.B) {
 }
 
 func BenchmarkSequenceHitOverlap(b *testing.B) {
-	sm, err := NewMatchSeq(int64(time.Second), "frank", "burns")
+	sm, err := NewMatchSeq(int64(time.Second), makeTermsA("frank", "burns")...)
 	if err != nil {
 		b.Fatalf("Expected err == nil, got %v", err)
 	}
@@ -524,7 +524,7 @@ func BenchmarkSeqRunawayMatch(b *testing.B) {
 	zerolog.SetGlobalLevel(zerolog.Disabled)
 	defer zerolog.SetGlobalLevel(level)
 
-	sm, err := NewMatchSeq(1000000, "frank", "burns")
+	sm, err := NewMatchSeq(1000000, makeTermsA("frank", "burns")...)
 	if err != nil {
 		b.Fatalf("Expected err == nil, got %v", err)
 	}

--- a/pkg/match/set.go
+++ b/pkg/match/set.go
@@ -16,9 +16,10 @@ type MatchSet struct {
 	terms   []termT
 }
 
-func NewMatchSet(window int64, setTerms ...string) (*MatchSet, error) {
+func NewMatchSet(window int64, setTerms ...TermT) (*MatchSet, error) {
+
 	var (
-		dupes  = make(map[string]struct{})
+		dupes  = make(map[TermT]struct{})
 		nTerms = len(setTerms)
 		terms  = make([]termT, nTerms)
 	)
@@ -32,7 +33,7 @@ func NewMatchSet(window int64, setTerms ...string) (*MatchSet, error) {
 	}
 
 	for i, term := range setTerms {
-		if m, err := makeMatchFunc(term); err != nil {
+		if m, err := term.NewMatcher(); err != nil {
 			return nil, err
 		} else {
 			terms[i].matcher = m

--- a/pkg/match/set_test.go
+++ b/pkg/match/set_test.go
@@ -114,7 +114,7 @@ func TestSet(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			sm, err := NewMatchSet(tc.window, tc.terms...)
+			sm, err := NewMatchSet(tc.window, makeTerms(tc.terms)...)
 			if err != nil {
 				t.Fatalf("Expected err == nil, got %v", err)
 			}
@@ -154,7 +154,7 @@ func TestSet(t *testing.T) {
 // Dupes not yet implemented.
 func TestSetDupes(t *testing.T) {
 
-	_, err := NewMatchSet(10, "alpha", "alpha")
+	_, err := NewMatchSet(10, makeTermsA("alpha", "alpha")...)
 	if err != ErrDuplicateTerm {
 		t.Fatalf("Expected err == ErrDuplicateTerm, got %v", err)
 	}

--- a/pkg/match/single.go
+++ b/pkg/match/single.go
@@ -8,8 +8,8 @@ type MatchSingle struct {
 	matcher MatchFunc
 }
 
-func NewMatchSingle(str string) (*MatchSingle, error) {
-	m, err := makeMatchFunc(str)
+func NewMatchSingle(term TermT) (*MatchSingle, error) {
+	m, err := term.NewMatcher()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Handle edge case where duplicates on sequence were incorrectly firing after a garbage collection.

Add explicit typing to terms.
Note: the compiler should prefer Raw over Regex.
If unsure, use the match.IsRegEx function to determine the type of the term. @tonymeehan 
