### PR TITLE
Move scanner unit tests to scanner.

### DIFF
--- a/pkg/format/cri.go
+++ b/pkg/format/cri.go
@@ -20,12 +20,6 @@ const (
 )
 
 var (
-	ErrNoTimestamp   = errors.New("no timestamp delimeter")
-	ErrNoStreamType  = errors.New("no stream delimeter")
-	ErrNoTag         = errors.New("no tag delimeter")
-	ErrUnknownStream = errors.New("unknown stream type")
-	ErrParseTimesamp = errors.New("fail parse timestamp")
-
 	sliceStdout = []byte(tokenStdout)
 	sliceStderr = []byte(tokenStderr)
 )

--- a/pkg/format/detect.go
+++ b/pkg/format/detect.go
@@ -18,8 +18,6 @@ type ParserI interface {
 	ReadEntry(line []byte) (LogEntry, error)
 }
 
-var ErrFormatDetect = errors.New("fail to detect log format")
-
 type DetectFormatFunc func(line []byte) (FactoryI, int64, error)
 
 var supportedFormats = []DetectFormatFunc{

--- a/pkg/format/error.go
+++ b/pkg/format/error.go
@@ -1,0 +1,17 @@
+package format
+
+import (
+	"errors"
+)
+
+var (
+	ErrFormatDetect   = errors.New("fail to detect log format")
+	ErrNoTimestamp    = errors.New("no timestamp delimeter")
+	ErrNoStreamType   = errors.New("no stream delimeter")
+	ErrNoTag          = errors.New("no tag delimeter")
+	ErrUnknownStream  = errors.New("unknown stream type")
+	ErrParseTimesamp  = errors.New("fail parse timestamp")
+	ErrJsonTimeField  = errors.New("fail to extract time field")
+	ErrJsonUnmarshal  = errors.New("fail JSON unmarshal")
+	ErrMatchTimestamp = errors.New("fail match timestamp")
+)

--- a/pkg/format/json.go
+++ b/pkg/format/json.go
@@ -2,14 +2,11 @@ package format
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"time"
 
 	"github.com/goccy/go-json"
 )
-
-var ErrJsonUnmarshal = fmt.Errorf("fail JSON unmarshal")
 
 func NewJsonFactory() FactoryI {
 	return &jsonFactoryT{}
@@ -48,7 +45,7 @@ func (f *jsonFmtT) ReadTimestamp(rdr io.Reader) (ts int64, err error) {
 		return
 	}
 
-	return line.Time.UnixNano(), nil
+	return line.Time.UTC().UnixNano(), nil
 }
 
 // Read Docker JSON format

--- a/pkg/format/json_custom.go
+++ b/pkg/format/json_custom.go
@@ -9,8 +9,6 @@ import (
 	"github.com/goccy/go-json"
 )
 
-var ErrJsonTimeField = errors.New("fail to extract time field")
-
 type jsonCustomFmtT struct {
 	path    *json.Path
 	fmtTime string
@@ -75,7 +73,7 @@ func (f *jsonCustomFmtT) parseTime(stime string) (ts int64, err error) {
 		return
 	}
 
-	return t.UnixNano(), nil
+	return t.UTC().UnixNano(), nil
 }
 
 // Read custom JSON Format

--- a/pkg/format/json_custom_test.go
+++ b/pkg/format/json_custom_test.go
@@ -1,71 +1,9 @@
 package format
 
 import (
-	"strings"
 	"testing"
 	"time"
-
-	"github.com/prequel-dev/prequel-logmatch/pkg/scanner"
 )
-
-func TestJsonCustomCorrupt(t *testing.T) {
-	var (
-		maxSz = 1024 * 1024
-		sr    = scanner.NewStdReadScan(maxSz)
-		rdr   = strings.NewReader(corrupted)
-	)
-
-	factory, err := NewJsonCustomFactory("$.time", time.RFC3339Nano)
-	if err != nil {
-		t.Errorf("Expected nil error got %v", err)
-	}
-
-	f := factory.New()
-
-	err = scanner.ScanForward(rdr, f.ReadEntry, sr.Scan, scanner.WithMaxSize(maxSz))
-
-	if err != nil {
-		t.Errorf("Expected nil error got %v", err)
-	}
-
-	if len(sr.Logs) != 6 {
-		t.Errorf("Expected %d entries, got %d", 6, len(sr.Logs))
-	}
-
-	if sr.Clip {
-		t.Errorf("Expected no clip")
-	}
-}
-
-func TestJsonCustomLogsExtraLF(t *testing.T) {
-
-	var (
-		maxSz = 1024 * 1024
-		sr    = scanner.NewStdReadScan(maxSz)
-		rdr   = strings.NewReader("\n\n\n" + corrupted + "\n\n\n" + extra + "\n\n")
-	)
-
-	factory, err := NewJsonCustomFactory("$.time", time.RFC3339Nano)
-	if err != nil {
-		t.Errorf("Expected nil error got %v", err)
-	}
-
-	f := factory.New()
-
-	err = scanner.ScanForward(rdr, f.ReadEntry, sr.Scan, scanner.WithMaxSize(maxSz))
-
-	if err != nil {
-		t.Errorf("Expected nil error got %v", err)
-	}
-
-	if len(sr.Logs) != 8 {
-		t.Errorf("Expected %d entries, got %d", 8, len(sr.Logs))
-	}
-
-	if sr.Clip {
-		t.Errorf("Expected no clip")
-	}
-}
 
 func TestJsonCustomFunkyField(t *testing.T) {
 
@@ -83,8 +21,8 @@ func TestJsonCustomFunkyField(t *testing.T) {
 		t.Errorf("Expected nil error got %v", err)
 	}
 
-	if entry.Timestamp != 1326269700000000000 {
-		t.Errorf("Expected %d got %d", 1326293700000000000, entry.Timestamp)
+	if entry.Timestamp != 1326287700000000000 {
+		t.Errorf("Expected %d got %d", 1326287700000000000, entry.Timestamp)
 	}
 
 	if entry.Line != string(line) {

--- a/pkg/format/regex.go
+++ b/pkg/format/regex.go
@@ -2,16 +2,11 @@ package format
 
 import (
 	"bufio"
-	"errors"
 	"io"
 	"regexp"
 	"time"
 
 	"github.com/prequel-dev/prequel-logmatch/internal/pkg/pool"
-)
-
-var (
-	ErrNoMatch = errors.New("expected at least one match")
 )
 
 type TimeFormatCbT func(m []byte) (int64, error)
@@ -37,7 +32,7 @@ func WithTimeFormat(fmtTime string) TimeFormatCbT {
 			return 0, err
 		}
 
-		return t.UnixNano(), nil
+		return t.UTC().UnixNano(), nil
 	}
 }
 
@@ -85,7 +80,7 @@ func (f *regexFmtT) ReadTimestamp(rdr io.Reader) (ts int64, err error) {
 	if scanner.Scan() {
 		m := f.expTime.FindSubmatch(scanner.Bytes())
 		if len(m) <= 1 {
-			err = ErrNoTimestamp
+			err = ErrMatchTimestamp
 			return
 		}
 
@@ -102,7 +97,7 @@ func (f *regexFmtT) ReadTimestamp(rdr io.Reader) (ts int64, err error) {
 func (f *regexFmtT) ReadEntry(data []byte) (entry LogEntry, err error) {
 	m := f.expTime.FindSubmatch(data)
 	if len(m) <= 1 {
-		err = ErrNoTimestamp
+		err = ErrMatchTimestamp
 		return
 	}
 

--- a/pkg/format/regex_test.go
+++ b/pkg/format/regex_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestRegex(t *testing.T) {
 
-	exp := `^\b[A-Z][a-z]{2} [A-Z][a-z]{2} [ _]?\d{1,2} \d{2}:\d{2}:\d{2} \d{4}\b`
+	exp := `^((?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)\s(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2}\s\d{2}:\d{2}:\d{2}\s\d{4}) `
 	factory, err := NewRegexFactory(exp, WithTimeFormat(time.ANSIC))
 	if err != nil {
 		t.Errorf("Expected nil error got %v", err)

--- a/pkg/scanner/forward.go
+++ b/pkg/scanner/forward.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/prequel-dev/prequel-logmatch/internal/pkg/pool"
+	"github.com/prequel-dev/prequel-logmatch/pkg/format"
 )
 
 func ScanForward(rdr io.Reader, parseF ParseFuncT, scanF ScanFuncT, opts ...ScanOptT) error {
@@ -92,10 +93,12 @@ func bindCallbacks(scanF ScanFuncT, o scanOpt) (ScanFuncT, ErrFuncT, flushFuncT)
 
 	// On error, append line to pending entry
 	nErrF := func(line []byte, err error) error {
-		if builder.Len() == 0 {
-			builder.WriteString(pending.Line)
+		if err == format.ErrMatchTimestamp {
+			if builder.Len() == 0 {
+				builder.WriteString(pending.Line)
+			}
+			builder.Write(line)
 		}
-		builder.Write(line)
 		return o.errF(line, err)
 	}
 


### PR DESCRIPTION
Refine 'nofold' feature to append only no timestamp match failure. Fix timezone issues.