### PR TITLE
Correctly flush out any pending fold data on final flush.

### DIFF
--- a/pkg/format/cri.go
+++ b/pkg/format/cri.go
@@ -75,7 +75,7 @@ func (f *criFmtT) ReadEntry(line []byte) (entry LogEntry, err error) {
 
 	ts, err := time.Parse(time.RFC3339Nano, string(line[:idx]))
 	if err != nil {
-		err = errors.Join(ErrParseTimesamp, err)
+		err = errors.Join(ErrParseTimestamp, err)
 		return
 	}
 

--- a/pkg/format/cri_test.go
+++ b/pkg/format/cri_test.go
@@ -25,9 +25,9 @@ func TestReadCriEntry(t *testing.T) {
 	}{
 		"empty":                  {data: "", werr: ErrNoTimestamp},
 		"ts_no_delimeter":        {data: "2016", werr: ErrNoTimestamp},
-		"ts_short1":              {data: "2016 ", werr: ErrParseTimesamp},
-		"ts_short2":              {data: "2016-10-06T00:17:09 ", werr: ErrParseTimesamp},
-		"ts_malformed":           {data: "2016-10-06T00:17:09.669794202z ", werr: ErrParseTimesamp},
+		"ts_short1":              {data: "2016 ", werr: ErrParseTimestamp},
+		"ts_short2":              {data: "2016-10-06T00:17:09 ", werr: ErrParseTimestamp},
+		"ts_malformed":           {data: "2016-10-06T00:17:09.669794202z ", werr: ErrParseTimestamp},
 		"ts_short_ok":            {data: shortTimestampS + " ", werr: ErrNoStreamType},
 		"ts_ok_no_stream":        {data: longTimestampS + " ", werr: ErrNoStreamType},
 		"malformed_stream":       {data: longTimestampS + "  ", werr: ErrUnknownStream},

--- a/pkg/format/error.go
+++ b/pkg/format/error.go
@@ -10,7 +10,7 @@ var (
 	ErrNoStreamType   = errors.New("no stream delimeter")
 	ErrNoTag          = errors.New("no tag delimeter")
 	ErrUnknownStream  = errors.New("unknown stream type")
-	ErrParseTimesamp  = errors.New("fail parse timestamp")
+	ErrParseTimestamp = errors.New("fail parse timestamp")
 	ErrJsonTimeField  = errors.New("fail to extract time field")
 	ErrJsonUnmarshal  = errors.New("fail JSON unmarshal")
 	ErrMatchTimestamp = errors.New("fail match timestamp")

--- a/pkg/format/json_custom.go
+++ b/pkg/format/json_custom.go
@@ -69,7 +69,7 @@ func (f *jsonCustomFmtT) ReadTimestamp(rdr io.Reader) (ts int64, err error) {
 func (f *jsonCustomFmtT) parseTime(stime string) (ts int64, err error) {
 	t, err := time.Parse(f.fmtTime, stime)
 	if err != nil {
-		err = errors.Join(ErrParseTimesamp, err)
+		err = errors.Join(ErrParseTimestamp, err)
 		return
 	}
 

--- a/pkg/format/rfc3339.go
+++ b/pkg/format/rfc3339.go
@@ -58,7 +58,7 @@ func (f *rfc339NanoFmtT) ReadEntry(line []byte) (entry LogEntry, err error) {
 
 	ts, err := time.Parse(time.RFC3339Nano, string(line[:idx]))
 	if err != nil {
-		err = errors.Join(ErrParseTimesamp, err)
+		err = errors.Join(ErrParseTimestamp, err)
 		return
 	}
 


### PR DESCRIPTION
Relax error restriction on fold, but enforce utf8 validity. 
Fix ErrParseTimestamp typo.