### PR TITLE
Fix typo

### DIFF
--- a/pkg/scanner/reverse.go
+++ b/pkg/scanner/reverse.go
@@ -47,7 +47,7 @@ LOOP:
 			continue
 		}
 
-		if entry.Timestamp < o.stop {
+		if entry.Timestamp < stop {
 			break LOOP
 		}
 


### PR DESCRIPTION
@scunningham did you mean to use `stop` instead of `o.stop`?
cause I see the value is assigned before the loop 
https://github.com/prequel-dev/prequel-logmatch/compare/main...aleksmaus:fix/stop?expand=1#diff-cab49b2615ef7ed2ca22f7ce30e4f35664cecda5fe59f2a0faccd540d798bb3cR25
but not used 