### PR TITLE
Extend interface to allow cache of a decoded structure across matchers.

### DIFF
--- a/pkg/entry/entry.go
+++ b/pkg/entry/entry.go
@@ -14,7 +14,7 @@ type LogEntry struct {
 // Uses msgpack size as an estimate;  not exactly right.
 // Cannot use e.MsgSize() because it doesn't properly account for omitted matches
 
-func (z LogEntry) Size() (s int) {
+func (z LogEntry) UpperBound() (s int) {
 	// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 	s = 1 + 2 + msgp.StringPrefixSize + len(z.Line) + 2 + msgp.StringPrefixSize + len(z.Stream) + 2 + msgp.Int64Size
 

--- a/pkg/match/inverse_seq.go
+++ b/pkg/match/inverse_seq.go
@@ -3,7 +3,6 @@ package match
 import (
 	"slices"
 
-	"github.com/prequel-dev/prequel-logmatch/pkg/entry"
 	"github.com/rs/zerolog/log"
 )
 
@@ -119,7 +118,7 @@ func maybeAnchor(nTerms int, dupeMap map[int]int, anchor uint8) bool {
 	return false
 }
 
-func (r *InverseSeq) Scan(e entry.LogEntry) (hits Hits) {
+func (r *InverseSeq) Scan(e *ScanLine) (hits Hits) {
 	if e.Timestamp < r.clock {
 		log.Warn().
 			Str("line", e.Line).
@@ -137,7 +136,7 @@ func (r *InverseSeq) Scan(e entry.LogEntry) (hits Hits) {
 	switch {
 	case len(r.terms[0].asserts) > 0:
 	case r.gcLeft > 0:
-	case !r.terms[0].matcher(e.Line):
+	case !r.terms[0].matcher(e):
 		return
 	default:
 		zeroMatch = true
@@ -145,7 +144,7 @@ func (r *InverseSeq) Scan(e entry.LogEntry) (hits Hits) {
 
 	// Run resets
 	for i, reset := range r.resets {
-		if reset.matcher(e.Line) {
+		if reset.matcher(e) {
 			r.resets[i].resets = append(reset.resets, e.Timestamp)
 			r.resetGcMark(e.Timestamp + r.gcLeft + r.gcRight)
 		}
@@ -153,8 +152,8 @@ func (r *InverseSeq) Scan(e entry.LogEntry) (hits Hits) {
 
 	// Run the active terms
 	for i := range r.nActive {
-		if r.terms[i].matcher(e.Line) {
-			r.terms[i].asserts = append(r.terms[i].asserts, e)
+		if r.terms[i].matcher(e) {
+			r.terms[i].asserts = append(r.terms[i].asserts, e.LogEntry)
 		}
 	}
 
@@ -162,12 +161,12 @@ func (r *InverseSeq) Scan(e entry.LogEntry) (hits Hits) {
 
 		switch {
 		case zeroMatch:
-		case !r.terms[r.nActive].matcher(e.Line):
+		case !r.terms[r.nActive].matcher(e):
 			// No match on active term; NOOP.
 			return
 		}
 
-		r.terms[r.nActive].asserts = append(r.terms[r.nActive].asserts, e)
+		r.terms[r.nActive].asserts = append(r.terms[r.nActive].asserts, e.LogEntry)
 		r.resetGcMark(e.Timestamp + r.gcRight)
 
 		// We have matched the active term; check if there are dupes before advancing.

--- a/pkg/match/inverse_seq_test.go
+++ b/pkg/match/inverse_seq_test.go
@@ -830,7 +830,7 @@ func BenchmarkSeqInverseMisses(b *testing.B) {
 		b.Fatalf("Expected err == nil, got %v", err)
 	}
 
-	noop := LogEntry{Line: "NOOP", Timestamp: time.Now().UnixNano()}
+	noop := NewScanLine().ResetLine(time.Now().UnixNano(), "NOOP")
 
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
@@ -854,7 +854,7 @@ func BenchmarkSeqInverseMissesWithReset(b *testing.B) {
 		b.Fatalf("Expected err == nil, got %v", err)
 	}
 
-	noop := LogEntry{Line: "NOOP", Timestamp: time.Now().UnixNano()}
+	noop := NewScanLine().ResetLine(time.Now().UnixNano(), "NOOP")
 
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
@@ -872,8 +872,8 @@ func BenchmarkSeqInverseHitSequence(b *testing.B) {
 	}
 
 	ts := time.Now().UnixNano()
-	ev1 := LogEntry{Line: "Let's be frank"}
-	ev2 := LogEntry{Line: "Mr burns I am"}
+	ev1 := NewScanLine().ResetLine(ts, "Let's be frank")
+	ev2 := NewScanLine().ResetLine(ts, "Mr burns I am")
 
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
@@ -898,8 +898,8 @@ func BenchmarkSeqInverseHitOverlap(b *testing.B) {
 
 	var (
 		ts  = time.Now().UnixNano()
-		ev1 = LogEntry{Line: "Let's be frank"}
-		ev2 = LogEntry{Line: "Mr burns I am"}
+		ev1 = NewScanLine().ResetLine(ts, "Let's be frank")
+		ev2 = NewScanLine().ResetLine(ts, "Mr burns I am")
 	)
 
 	b.ReportAllocs()
@@ -931,7 +931,7 @@ func BenchmarkSeqInverseRunawayMatch(b *testing.B) {
 	}
 
 	var (
-		ev1 = LogEntry{Line: "Let's be frank"}
+		ev1 = NewScanLine().ResetLine(0, "Let's be frank")
 	)
 
 	b.ReportAllocs()
@@ -951,8 +951,8 @@ func BenchmarkSeqInverseDupes(b *testing.B) {
 
 	var (
 		clock int64
-		ev1   = LogEntry{Line: "Bring me a shrubbery"}
-		ev2   = LogEntry{Line: "Let's be frank"}
+		ev1   = NewScanLine().ResetLine(0, "Bring me a shrubbery")
+		ev2   = NewScanLine().ResetLine(0, "Let's be frank")
 	)
 
 	b.ReportAllocs()
@@ -1002,8 +1002,8 @@ func BenchmarkSeqInverseDupesWithResets(b *testing.B) {
 
 	var (
 		clock int64
-		ev1   = LogEntry{Line: "Bring me a shrubbery"}
-		ev2   = LogEntry{Line: "Let's be frank"}
+		ev1   = NewScanLine().ResetLine(0, "Bring me a shrubbery")
+		ev2   = NewScanLine().ResetLine(0, "Let's be frank")
 	)
 
 	b.ReportAllocs()

--- a/pkg/match/inverse_set.go
+++ b/pkg/match/inverse_set.go
@@ -5,7 +5,6 @@ import (
 	"math"
 	"slices"
 
-	"github.com/prequel-dev/prequel-logmatch/pkg/entry"
 	"github.com/rs/zerolog/log"
 )
 
@@ -65,7 +64,7 @@ func NewInverseSet(window int64, setTerms []TermT, resetTerms []ResetT) (*Invers
 	}, nil
 }
 
-func (r *InverseSet) Scan(e entry.LogEntry) (hits Hits) {
+func (r *InverseSet) Scan(e *ScanLine) (hits Hits) {
 	if e.Timestamp < r.clock {
 		log.Warn().
 			Str("line", e.Line).
@@ -81,9 +80,9 @@ func (r *InverseSet) Scan(e entry.LogEntry) (hits Hits) {
 	// For a set, must scan all terms.
 	// Cannot short circuit like a sequence.
 	for i, term := range r.terms {
-		if term.matcher(e.Line) {
+		if term.matcher(e) {
 			// Append the match to the assert list
-			r.terms[i].asserts = append(r.terms[i].asserts, e)
+			r.terms[i].asserts = append(r.terms[i].asserts, e.LogEntry)
 
 			// If not a dupe or we've hit the dupe count, set the hot mask
 			if dupeCnt := r.dupeMap[i]; len(r.terms[i].asserts) > dupeCnt {
@@ -102,7 +101,7 @@ func (r *InverseSet) Scan(e entry.LogEntry) (hits Hits) {
 
 	// Run resets
 	for i, reset := range r.resets {
-		if reset.matcher(e.Line) {
+		if reset.matcher(e) {
 			r.resets[i].resets = append(reset.resets, e.Timestamp)
 			r.resetGcMark(e.Timestamp + r.gcLeft + r.gcRight)
 		}

--- a/pkg/match/inverse_set_test.go
+++ b/pkg/match/inverse_set_test.go
@@ -749,7 +749,7 @@ func BenchmarkSetInverseMisses(b *testing.B) {
 		b.Fatalf("Expected err == nil, got %v", err)
 	}
 
-	noop := LogEntry{Line: "NOOP", Timestamp: time.Now().UnixNano()}
+	noop := NewScanLine().ResetLine(time.Now().UnixNano(), "NOOP")
 
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
@@ -773,7 +773,7 @@ func BenchmarkSetInverseMissesWithReset(b *testing.B) {
 		b.Fatalf("Expected err == nil, got %v", err)
 	}
 
-	noop := LogEntry{Line: "NOOP", Timestamp: time.Now().UnixNano()}
+	noop := NewScanLine().ResetLine(time.Now().UnixNano(), "NOOP")
 
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
@@ -791,8 +791,8 @@ func BenchmarkSetInverseHitSequence(b *testing.B) {
 	}
 
 	ts := time.Now().UnixNano()
-	ev1 := LogEntry{Line: "Let's be frank"}
-	ev2 := LogEntry{Line: "Mr burns I am"}
+	ev1 := NewScanLine().ResetLine(ts, "Let's be frank")
+	ev2 := NewScanLine().ResetLine(ts, "Mr burns I am")
 
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
@@ -817,8 +817,8 @@ func BenchmarkSetInverseHitOverlap(b *testing.B) {
 
 	var (
 		ts  = time.Now().UnixNano()
-		ev1 = LogEntry{Line: "Let's be frank"}
-		ev2 = LogEntry{Line: "Mr burns I am"}
+		ev1 = NewScanLine().ResetLine(ts, "Let's be frank")
+		ev2 = NewScanLine().ResetLine(ts, "Mr burns I am")
 	)
 
 	b.ReportAllocs()
@@ -850,7 +850,7 @@ func BenchmarkSetInverseRunawayMatch(b *testing.B) {
 	}
 
 	var (
-		ev1 = LogEntry{Line: "Let's be frank"}
+		ev1 = NewScanLine().ResetLine(time.Now().UnixNano(), "Let's be frank")
 	)
 
 	b.ReportAllocs()

--- a/pkg/match/inverse_test.go
+++ b/pkg/match/inverse_test.go
@@ -3,8 +3,6 @@ package match
 import (
 	"fmt"
 	"testing"
-
-	"github.com/prequel-dev/prequel-logmatch/pkg/entry"
 )
 
 type stepT struct {
@@ -49,7 +47,7 @@ func (c casesT) run(t *testing.T, factory func(caseT) (Matcher, error)) {
 
 				if step.line != "" {
 					var (
-						entry = entry.LogEntry{Timestamp: stamp, Line: step.line}
+						entry = NewScanLine().ResetLine(stamp, step.line)
 						hits  = sm.Scan(entry)
 					)
 

--- a/pkg/match/match.go
+++ b/pkg/match/match.go
@@ -1,7 +1,6 @@
 package match
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"regexp"
@@ -9,7 +8,6 @@ import (
 
 	"github.com/prequel-dev/prequel-logmatch/pkg/entry"
 
-	"github.com/goccy/go-yaml"
 	"github.com/itchyny/gojq"
 	"github.com/rs/zerolog/log"
 )
@@ -22,7 +20,7 @@ var (
 
 type Matcher interface {
 	Eval(int64) Hits
-	Scan(e entry.LogEntry) Hits
+	Scan(*ScanLine) Hits
 	GarbageCollect(int64)
 }
 
@@ -65,7 +63,7 @@ type TermT struct {
 	Value string
 }
 
-type MatchFunc func(string) bool
+type MatchFunc func(*ScanLine) bool
 
 func (tt TermT) NewMatcher() (m MatchFunc, err error) {
 
@@ -97,8 +95,8 @@ func IsRegex(v string) bool {
 }
 
 func makeRawMatch(s string) MatchFunc {
-	return func(line string) bool {
-		return strings.Contains(line, s)
+	return func(e *ScanLine) bool {
+		return strings.Contains(e.Line, s)
 	}
 }
 
@@ -108,53 +106,20 @@ func makeRegexMatch(term string) (MatchFunc, error) {
 		return nil, err
 	}
 
-	return func(line string) bool {
-		return exp.MatchString(line)
+	return func(e *ScanLine) bool {
+		return exp.MatchString(e.Line)
 	}, nil
 }
 
-func makeJsonUnmarshal() func(string) (any, error) {
-	// memorize unmarshaller; this avoids unmarshalling
-	// multiple times if there is more than one Jq matcher installed
-
-	var (
-		lastLine  string
-		lastError error
-		lastValue any
-	)
-
-	return func(line string) (any, error) {
-		if line == lastLine {
-			return lastValue, lastError
-		}
-		lastLine = line
-		lastError = json.Unmarshal([]byte(line), &lastValue)
-		return lastValue, lastError
-	}
+func jsonUnmarshalThunk(e *ScanLine) (any, error) {
+	return e.DecodeJson()
 }
 
-func makeYamlUnmarshal() func(string) (any, error) {
-	// memorize unmarshaller; this avoids unmarshalling
-	// multiple times if there is more than one Jq matcher installed
-
-	var (
-		lastLine  string
-		lastError error
-		lastValue any
-	)
-
-	return func(line string) (any, error) {
-		if line == lastLine {
-			return lastValue, lastError
-		}
-		lastLine = line
-		lastError = yaml.Unmarshal([]byte(line), &lastValue)
-		return lastValue, lastError
-	}
+func yamlUnmarshalThunk(e *ScanLine) (any, error) {
+	return e.DecodeYaml()
 }
 
 func NewJqJson(term string) (MatchFunc, error) {
-	unmarshal := makeJsonUnmarshal()
 
 	query, err := gojq.Parse(term)
 	if err != nil {
@@ -166,7 +131,7 @@ func NewJqJson(term string) (MatchFunc, error) {
 		return nil, fmt.Errorf("%w: compile fail: %w", ErrTermCompile, err)
 	}
 
-	return _makeJqMatch(term, code, unmarshal), nil
+	return _makeJqMatch(term, code, jsonUnmarshalThunk), nil
 }
 
 func makeJqMatch(term TermT) (MatchFunc, error) {
@@ -174,9 +139,9 @@ func makeJqMatch(term TermT) (MatchFunc, error) {
 
 	switch term.Type {
 	case TermJqJson:
-		unmarshal = makeJsonUnmarshal()
+		unmarshal = jsonUnmarshalThunk
 	case TermJqYaml:
-		unmarshal = makeYamlUnmarshal()
+		unmarshal = yamlUnmarshalThunk
 	default:
 		return nil, errors.New("unknown jq format")
 	}
@@ -194,21 +159,20 @@ func makeJqMatch(term TermT) (MatchFunc, error) {
 	return _makeJqMatch(term.Value, code, unmarshal), nil
 }
 
-type unmarshalFuncT func(string) (any, error)
+type unmarshalFuncT func(e *ScanLine) (any, error)
 
 func _makeJqMatch(term string, code *gojq.Code, unmarshal unmarshalFuncT) MatchFunc {
-	return func(line string) (match bool) {
+	return func(e *ScanLine) (match bool) {
 		// Avoid unnecessary allocation on the cast
 		var (
 			err error
 			v   any
 		)
 
-		// This is obviously not ideal;  unmarshal the entire payload
-		// just to do a matching check is extremely wasteful.
-		// Ideally we'd have an inline matcher for both JSON and YAML.
-		if v, err = unmarshal(line); err != nil {
-			log.Debug().Err(err).Str("line", line).Msg("Fail parse JSON log line")
+		// Unmarshal the line (JSON or YAML) into an interface{} for gojq to consume.
+		// The ScanLine will cache the result, so this is only expensive on the first call for a given line.
+		if v, err = unmarshal(e); err != nil {
+			log.Debug().Err(err).Str("line", e.Line).Msg("Fail parse log line")
 			return false
 		}
 		iter := code.Run(v)
@@ -222,9 +186,9 @@ func _makeJqMatch(term string, code *gojq.Code, unmarshal unmarshalFuncT) MatchF
 					break
 				}
 				log.Debug().Err(err).
-					Str("line", line).
+					Str("line", e.Line).
 					Str("term", term).
-					Msg("Fail jq query on JSON line")
+					Msg("Fail jq query")
 				match = false
 				break
 			}

--- a/pkg/match/match_test.go
+++ b/pkg/match/match_test.go
@@ -18,17 +18,17 @@ func TestMatchJson(t *testing.T) {
 	}
 
 	// Happy path
-	if !m(`{"shrubbery":"apple"}`) {
+	if !m(scanLineFromLine(`{"shrubbery":"apple"}`)) {
 		t.Errorf("Expected match, got fail.")
 	}
 
 	// Sad path
-	if m(`{"nope":"apple"}`) {
+	if m(scanLineFromLine(`{"nope":"apple"}`)) {
 		t.Errorf("Expected no match, got match.")
 	}
 
 	// Error path
-	if m(`not json`) {
+	if m(scanLineFromLine(`not json`)) {
 		t.Errorf("Expected no match, got match.")
 	}
 }
@@ -46,7 +46,7 @@ func TestMatchJsonHalt(t *testing.T) {
 	}
 
 	// Fail path
-	if m(`{"a":"shrubbery"}`) {
+	if m(scanLineFromLine(`{"a":"shrubbery"}`)) {
 		t.Errorf("Expected no match, got match.")
 	}
 
@@ -60,12 +60,12 @@ func TestNewJqJson(t *testing.T) {
 	}
 
 	// Happy path
-	if !m(`{"shrubbery":"apple"}`) {
+	if !m(scanLineFromLine(`{"shrubbery":"apple"}`)) {
 		t.Errorf("Expected match, got fail.")
 	}
 
 	// Sad path
-	if m(`{"nope":"apple"}`) {
+	if m(scanLineFromLine(`{"nope":"apple"}`)) {
 		t.Errorf("Expected no match, got match.")
 	}
 }
@@ -92,7 +92,7 @@ func TestJqJsonBadLine(t *testing.T) {
 		t.Fatalf("Expected nil, got :%v", err)
 	}
 
-	badLine := `apple, but not json`
+	badLine := scanLineFromLine(`apple, but not json`)
 
 	// Execute path for coverage
 	if mFunc(badLine) {
@@ -117,12 +117,12 @@ func TestMatchJsonString(t *testing.T) {
 	}
 
 	// Happy path
-	if !m(`{"shrubbery":"apple"}`) {
+	if !m(scanLineFromLine(`{"shrubbery":"apple"}`)) {
 		t.Errorf("Expected match, got fail.")
 	}
 
 	// Sad path
-	if m(`{"shrubbery":"xapple"}`) {
+	if m(scanLineFromLine(`{"shrubbery":"xapple"}`)) {
 		t.Errorf("Expected no match, got match.")
 	}
 
@@ -140,16 +140,16 @@ func TestMatchJsonRegex(t *testing.T) {
 	}
 
 	// Happy path
-	if !m(`{"shrubbery":"apple"}`) {
+	if !m(scanLineFromLine(`{"shrubbery":"apple"}`)) {
 		t.Errorf("Expected match, got fail.")
 	}
 
-	if !m(`{"shrubbery":"applex"}`) {
+	if !m(scanLineFromLine(`{"shrubbery":"applex"}`)) {
 		t.Errorf("Expected match, got fail.")
 	}
 
 	// Sad path
-	if m(`{"shrubbery":"banana"}`) {
+	if m(scanLineFromLine(`{"shrubbery":"banana"}`)) {
 		t.Errorf("Expected no match, got match.")
 	}
 }
@@ -166,12 +166,12 @@ func TestMatchYaml(t *testing.T) {
 	}
 
 	// Happy path
-	if !m(`shrubbery: apple`) {
+	if !m(scanLineFromLine(`shrubbery: apple`)) {
 		t.Errorf("Expected match, got fail.")
 	}
 
 	// Sad path
-	if m(`nope: apple`) {
+	if m(scanLineFromLine(`nope: apple`)) {
 		t.Errorf("Expected no match, got match.")
 	}
 }
@@ -188,12 +188,12 @@ func TestMatchRegex(t *testing.T) {
 	}
 
 	// Happy path
-	if !m(`HELLO`) {
+	if !m(scanLineFromLine(`HELLO`)) {
 		t.Errorf("Expected match, got fail.")
 	}
 
 	// Sad path
-	if m(`hello`) {
+	if m(scanLineFromLine(`hello`)) {
 		t.Errorf("Expected no match, got match.")
 	}
 }
@@ -244,7 +244,7 @@ func TestJqYamlBadLine(t *testing.T) {
 		t.Fatalf("Expected nil, got :%v", err)
 	}
 
-	badLine := `apple, but not yaml`
+	badLine := scanLineFromLine(`apple, but not yaml`)
 
 	// Execute path for coverage
 	if mFunc(badLine) {
@@ -337,11 +337,16 @@ func BenchmarkMatchJson(b *testing.B) {
 		m3, _ = tt3.NewMatcher()
 	)
 
+	l1 := NewScanLine().ResetLine(0, jsonData)
+	l2 := NewScanLine().ResetLine(0, "{}")
+	lines := []*ScanLine{l1, l2}
+
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		m1(jsonData)
-		m2(jsonData)
-		m3(jsonData)
+	for i := range b.N {
+		e := lines[i%2]
+		m1(e)
+		m2(e)
+		m3(e)
 	}
 
 }
@@ -545,7 +550,9 @@ func TestJqMatchRuntimeFailures(t *testing.T) {
 				t.Fatalf("Failed to create matcher: %v", err)
 			}
 
-			result := matcher(tt.input)
+			e := NewScanLine().ResetLine(0, tt.input)
+
+			result := matcher(e)
 			if result != tt.expected {
 				t.Errorf("Expected %v for input %q, got %v", tt.expected, tt.input, result)
 			}
@@ -603,7 +610,7 @@ func TestJqMatchWithCachedUnmarshaling(t *testing.T) {
 		t.Fatalf("Failed to create matcher: %v", err)
 	}
 
-	input := "{\"field\": \"value\"}"
+	input := scanLineFromLine("{\"field\": \"value\"}")
 
 	// First call - should unmarshal
 	result1 := matcher(input)
@@ -618,7 +625,8 @@ func TestJqMatchWithCachedUnmarshaling(t *testing.T) {
 	}
 
 	// Third call with different input - should unmarshal again
-	result3 := matcher("{\"field\": \"different\"}")
+	input = scanLineFromLine("{\"field\": \"different\"}")
+	result3 := matcher(input)
 	if !result3 {
 		t.Error("Expected true for different input")
 	}
@@ -637,8 +645,13 @@ func TestJqMatchErrorHandling(t *testing.T) {
 	}
 
 	// This should trigger the error path in the jq query
-	result := matcher("{\"field\": 123}")
+	input := scanLineFromLine("{\"field\": 123}")
+	result := matcher(input)
 	if result {
 		t.Error("Expected false when jq query has runtime error")
 	}
+}
+
+func scanLineFromLine(line string) *ScanLine {
+	return NewScanLine().ResetLine(0, line)
 }

--- a/pkg/match/scan_line.go
+++ b/pkg/match/scan_line.go
@@ -1,0 +1,95 @@
+package match
+
+import (
+	"encoding/json"
+
+	"github.com/goccy/go-yaml"
+)
+
+type decodeT int
+
+const (
+	decodeNone decodeT = iota
+	decodeJson
+	decodeYaml
+)
+
+// ScanLine is a wrapper around LogEntry that provides caching for decoded JSON and YAML data.
+// It is a replacement for the memoized struct that was previously used in the Matcher implementation,
+// and is designed to be used across multiple matchers without needing to duplicate the memoization logic in each matcher.
+// The cache is simple: it stores the type of the last decode (JSON or YAML), the decoded value, and any error that occurred during decoding.
+// Matchers that switch between JSON and YAML decoding on the same line will cause cache invalidation.
+// In general, matchers should stick to one decode type per line for best performance.
+
+type ScanLine struct {
+	LogEntry
+	cache *cacheT // Allocate lazily only if needed; TODO: Consider making this a weak ptr.
+}
+
+type cacheT struct {
+	ty  decodeT
+	ptr any
+	err error
+}
+
+func NewScanLine() *ScanLine {
+	return &ScanLine{}
+}
+
+// If cache is available and the line is the same, we can reuse the cached value.
+// If the line has changed, we need to clear the cache.
+func (s *ScanLine) _maybeClear(line string) {
+	switch {
+	case s.cache == nil:
+		// Fall through;  nothing to clear
+	case s.LogEntry.Line != line:
+		// Clear the cache if the line has changed
+		s.cache.ty = decodeNone
+		s.cache.ptr = nil
+		s.cache.err = nil
+	}
+}
+
+func (s *ScanLine) Reset(e LogEntry) *ScanLine {
+	s._maybeClear(e.Line)
+	s.LogEntry = e
+	return s
+}
+
+func (s *ScanLine) ResetLine(ts int64, line string) *ScanLine {
+	return s.Reset(LogEntry{Line: line, Timestamp: ts})
+}
+
+func (s *ScanLine) DecodeJson() (any, error) {
+	if s.cache != nil && s.cache.ty == decodeJson {
+		return s.cache.ptr, s.cache.err
+	}
+	return s._decode(decodeJson, json.Unmarshal)
+}
+
+func (s *ScanLine) DecodeYaml() (any, error) {
+	if s.cache != nil && s.cache.ty == decodeYaml {
+		return s.cache.ptr, s.cache.err
+	}
+	return s._decode(decodeYaml, yaml.Unmarshal)
+}
+
+func (s *ScanLine) _decode(ty decodeT, unmarshal func([]byte, interface{}) error) (any, error) {
+
+	if s.cache == nil {
+		s.cache = &cacheT{ty: ty}
+	} else {
+		s.cache.ty = ty
+		s.cache.err = nil
+	}
+
+	var dany any
+	if err := unmarshal([]byte(s.Line), &dany); err != nil {
+		s.cache.ptr = nil
+		s.cache.err = err
+		return nil, err
+	}
+
+	s.cache.ptr = dany
+	return dany, nil
+}

--- a/pkg/match/scan_line_test.go
+++ b/pkg/match/scan_line_test.go
@@ -1,0 +1,225 @@
+package match
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewScanLineAndReset(t *testing.T) {
+	le := LogEntry{Line: `{"foo":"bar"}`, Timestamp: 123}
+	sl := NewScanLine().Reset(le)
+	if sl.LogEntry.Line != le.Line {
+		t.Errorf("expected line %q, got %q", le.Line, sl.LogEntry.Line)
+	}
+
+	if sl.cache != nil {
+		t.Errorf("expected cache to be nil on new ScanLine, got %v", sl.cache)
+	}
+
+	// Force decoding to populate cache
+	_, err := sl.DecodeJson()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Reset with same line (should keep cache)
+	sl.Reset(le)
+	if sl.cache.ty != decodeJson {
+		t.Errorf("expected dtyp decodeJson after reset with same line, got %v", sl.cache.ty)
+	}
+	if !reflect.DeepEqual(sl.cache.ptr, map[string]any{"foo": "bar"}) {
+		t.Errorf("expected dany unchanged after reset with same line")
+	}
+
+	// Reset with different line (should clear cache)
+	le2 := LogEntry{Line: `{"baz":123}`, Timestamp: 456}
+	sl.Reset(le2)
+	if sl.cache.ty != decodeNone {
+		t.Errorf("expected dtyp decodeNone after reset with new line, got %v", sl.cache.ty)
+	}
+}
+
+func TestDecodeJson_Invalid(t *testing.T) {
+	sl := NewScanLine().ResetLine(0, `not a json`)
+	val, err := sl.DecodeJson()
+	if err == nil {
+		t.Errorf("expected error for invalid json")
+	}
+	if val != nil {
+		t.Errorf("expected nil value for invalid json")
+	}
+	if sl.cache == nil {
+		t.Fatalf("expected cache to be initialized on decode attempt")
+	}
+	if sl.cache.ty != decodeJson {
+		t.Errorf("should cache error result with dtyp decodeJson, got %v", sl.cache.ty)
+	}
+	if sl.cache.err != err {
+		t.Errorf("expected cached error to match returned error")
+	}
+}
+
+func TestDecodeYaml_SuccessAndCache(t *testing.T) {
+	sl := NewScanLine().ResetLine(0, "foo: bar\nnum: 42")
+
+	// First decode
+	val, err := sl.DecodeYaml()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m, ok := val.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any, got %T", val)
+	}
+
+	v, ok := m["foo"].(string)
+	if !ok || v != "bar" {
+		t.Errorf("unexpected value for foo: %v", m["foo"])
+	}
+	num, ok := m["num"].(uint64)
+	if !ok || num != 42 {
+		t.Errorf("unexpected value for num: %v", m["num"])
+	}
+
+	if sl.cache == nil {
+		t.Fatalf("expected cache to be initialized on decode")
+	}
+
+	if sl.cache.ty != decodeYaml {
+		t.Errorf("expected dtyp decodeYaml, got %v", sl.cache.ty)
+	}
+	if !reflect.DeepEqual(sl.cache.ptr, m) {
+		t.Errorf("expected dany to be cached value")
+	}
+
+	// Second decode (should use cache)
+	val2, err2 := sl.DecodeYaml()
+	if err2 != nil {
+		t.Fatalf("unexpected error on cached decode: %v", err2)
+	}
+
+	m, ok = val2.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any, got %T", val2)
+	}
+	v, ok = m["foo"].(string)
+	if !ok || v != "bar" {
+		t.Errorf("unexpected value for foo: %v", m["foo"])
+	}
+}
+
+func TestDecodeYaml_Invalid(t *testing.T) {
+	sl := NewScanLine().ResetLine(0, ":\n-")
+	val, err := sl.DecodeYaml()
+	if err == nil {
+		t.Errorf("expected error for invalid yaml")
+	}
+	if val != nil {
+		t.Errorf("expected nil value for invalid yaml")
+	}
+	if sl.cache == nil {
+		t.Fatalf("expected cache to be initialized on decode attempt")
+	}
+	if sl.cache.ty != decodeYaml {
+		t.Errorf("should cache error result with dtyp decodeYaml, got %v", sl.cache.ty)
+	}
+	if sl.cache.err != err {
+		t.Errorf("expected cached error to match returned error")
+	}
+}
+
+func TestDecodeJsonThenYaml(t *testing.T) {
+	sl := NewScanLine().ResetLine(0, `{"foo": "bar"}`)
+
+	// Decode as JSON
+	_, err := sl.DecodeJson()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sl.cache == nil {
+		t.Fatalf("expected cache to be initialized on decode")
+	}
+	if sl.cache.ty != decodeJson {
+		t.Errorf("expected dtyp decodeJson, got %v", sl.cache.ty)
+	}
+
+	// Decode as YAML (should decode again, not use JSON cache)
+	_, err = sl.DecodeYaml()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sl.cache.ty != decodeYaml {
+		t.Errorf("expected dtyp decodeYaml, got %v", sl.cache.ty)
+	}
+	if sl.cache.ptr == nil {
+		t.Errorf("expected dany to be set after YAML decode")
+	}
+	if sl.cache.err != nil {
+		t.Errorf("expected no error after successful YAML decode, got %v", sl.cache.err)
+	}
+
+}
+
+func TestDecodeYamlThenJson(t *testing.T) {
+	sl := NewScanLine().ResetLine(0, "foo: bar")
+
+	// Decode as YAML
+	valYaml, err := sl.DecodeYaml()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if valYaml == nil {
+		t.Errorf("expected non-nil value from YAML decode")
+	}
+	if sl.cache == nil {
+		t.Fatalf("expected cache to be initialized on decode")
+	}
+	if sl.cache.ty != decodeYaml {
+		t.Errorf("expected dtyp decodeYaml, got %v", sl.cache.ty)
+	}
+
+	// Decode as JSON (should decode again, not use YAML cache, and fail)
+	valJson, err := sl.DecodeJson()
+	if err == nil {
+		t.Errorf("expected error decoding YAML as JSON")
+	}
+	if valJson != nil {
+		t.Errorf("expected nil value for invalid JSON")
+	}
+	if sl.cache == nil {
+		t.Fatalf("expected cache to be initialized on decode attempt")
+	}
+	if sl.cache.ty != decodeJson {
+		t.Errorf("expected dtyp decodeJson, got %v", sl.cache.ty)
+	}
+	if sl.cache.err != err {
+		t.Errorf("expected cached error to match returned error")
+	}
+}
+
+func TestScanLine_Integration(t *testing.T) {
+	// Test full cycle: JSON, YAML, Reset, etc.
+	sl := NewScanLine().ResetLine(0, `{"a":1}`)
+	_, err := sl.DecodeJson()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	sl.Reset(LogEntry{Line: "b: 2"})
+	if sl.cache == nil {
+		t.Fatalf("expected cache to be initialized on reset")
+	}
+	if sl.cache.ty != decodeNone || sl.cache.ptr != nil {
+		t.Errorf("expected cache cleared after reset")
+	}
+	_, err = sl.DecodeYaml()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNoDecodeMeansNoCache(t *testing.T) {
+	sl := NewScanLine().ResetLine(0, "just a line")
+	if sl.cache != nil {
+		t.Errorf("expected cache to be nil if no decode attempted")
+	}
+}

--- a/pkg/match/seq.go
+++ b/pkg/match/seq.go
@@ -39,7 +39,7 @@ func NewMatchSeq(window int64, seqTerms ...TermT) (*MatchSeq, error) {
 	}, nil
 }
 
-func (r *MatchSeq) Scan(e LogEntry) (hits Hits) {
+func (r *MatchSeq) Scan(e *ScanLine) (hits Hits) {
 
 	if e.Timestamp < r.clock {
 		log.Warn().
@@ -54,12 +54,12 @@ func (r *MatchSeq) Scan(e LogEntry) (hits Hits) {
 	r.maybeGC(e.Timestamp)
 
 	for i := range r.nActive {
-		if r.terms[i].matcher(e.Line) {
-			r.terms[i].asserts = append(r.terms[i].asserts, e)
+		if r.terms[i].matcher(e) {
+			r.terms[i].asserts = append(r.terms[i].asserts, e.LogEntry)
 		}
 	}
 
-	if !r.terms[r.nActive].matcher(e.Line) {
+	if !r.terms[r.nActive].matcher(e) {
 		// No match on active term; NOOP.
 		return
 	}
@@ -69,14 +69,14 @@ func (r *MatchSeq) Scan(e LogEntry) (hits Hits) {
 
 	if len(r.terms[r.nActive].asserts) < dupeCnt {
 		// Not enough dupes yet; append current for later.
-		r.terms[r.nActive].asserts = append(r.terms[r.nActive].asserts, e)
+		r.terms[r.nActive].asserts = append(r.terms[r.nActive].asserts, e.LogEntry)
 		return
 	}
 
 	// We matched the active term, but not the all terms yet.
 	// Advance the active term and append the current event.
 	if r.nActive+1 < len(r.terms) {
-		r.terms[r.nActive].asserts = append(r.terms[r.nActive].asserts, e)
+		r.terms[r.nActive].asserts = append(r.terms[r.nActive].asserts, e.LogEntry)
 		r.nActive += 1
 		return
 	}
@@ -102,7 +102,7 @@ func (r *MatchSeq) Scan(e LogEntry) (hits Hits) {
 	}
 
 	// And the final event that triggered this hit
-	hits.Logs = append(hits.Logs, e)
+	hits.Logs = append(hits.Logs, e.LogEntry)
 
 	// Update active so the miniGC can cleanup up correctly
 	r.nActive += 1

--- a/pkg/match/seq_test.go
+++ b/pkg/match/seq_test.go
@@ -474,7 +474,7 @@ func BenchmarkSequenceMisses(b *testing.B) {
 		b.Fatalf("Expected err == nil, got %v", err)
 	}
 
-	noop := LogEntry{Line: "NOOP", Timestamp: time.Now().UnixNano()}
+	noop := NewScanLine().ResetLine(time.Now().UnixNano(), "NOOP")
 
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
@@ -490,8 +490,8 @@ func BenchmarkSequenceHitSequence(b *testing.B) {
 	}
 
 	ts := time.Now().UnixNano()
-	ev1 := LogEntry{Line: "Let's be frank"}
-	ev2 := LogEntry{Line: "Mr burns I am"}
+	ev1 := NewScanLine().ResetLine(ts, "Let's be frank")
+	ev2 := NewScanLine().ResetLine(ts, "Mr burns I am")
 
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
@@ -514,8 +514,8 @@ func BenchmarkSequenceHitOverlap(b *testing.B) {
 
 	var (
 		ts  = time.Now().UnixNano()
-		ev1 = LogEntry{Line: "Let's be frank"}
-		ev2 = LogEntry{Line: "Mr burns I am"}
+		ev1 = NewScanLine().ResetLine(ts, "Let's be frank")
+		ev2 = NewScanLine().ResetLine(ts, "Mr burns I am")
 	)
 
 	b.ReportAllocs()
@@ -546,7 +546,7 @@ func BenchmarkSeqRunawayMatch(b *testing.B) {
 	}
 
 	var (
-		ev1 = LogEntry{Line: "Let's be frank"}
+		ev1 = NewScanLine().ResetLine(0, "Let's be frank")
 	)
 
 	b.ReportAllocs()

--- a/pkg/match/set.go
+++ b/pkg/match/set.go
@@ -32,7 +32,7 @@ func NewMatchSet(window int64, setTerms ...TermT) (*MatchSet, error) {
 	}, nil
 }
 
-func (r *MatchSet) Scan(e LogEntry) (hits Hits) {
+func (r *MatchSet) Scan(e *ScanLine) (hits Hits) {
 	if e.Timestamp < r.clock {
 		log.Warn().
 			Str("line", e.Line).
@@ -48,9 +48,9 @@ func (r *MatchSet) Scan(e LogEntry) (hits Hits) {
 	// For a set, must scan all terms.
 	// Cannot short circuit like a sequence.
 	for i, term := range r.terms {
-		if term.matcher(e.Line) {
+		if term.matcher(e) {
 			// Append the match to the assert list
-			r.terms[i].asserts = append(r.terms[i].asserts, e)
+			r.terms[i].asserts = append(r.terms[i].asserts, e.LogEntry)
 
 			if dupeCnt := r.dupeMap[i]; len(r.terms[i].asserts) > dupeCnt {
 				r.hotMask.Set(i)

--- a/pkg/match/single.go
+++ b/pkg/match/single.go
@@ -17,11 +17,11 @@ func NewMatchSingle(term TermT) (*MatchSingle, error) {
 	return &MatchSingle{matcher: m}, nil
 }
 
-func (r *MatchSingle) Scan(e entry.LogEntry) (hits Hits) {
+func (r *MatchSingle) Scan(e *ScanLine) (hits Hits) {
 
-	if r.matcher(e.Line) {
+	if r.matcher(e) {
 		hits.Cnt = 1
-		hits.Logs = []entry.LogEntry{e}
+		hits.Logs = []entry.LogEntry{e.LogEntry}
 	}
 
 	return

--- a/pkg/match/single_test.go
+++ b/pkg/match/single_test.go
@@ -79,7 +79,7 @@ func BenchmarkSingleMiss(b *testing.B) {
 
 	var (
 		clock int64
-		ev1   = LogEntry{Line: "nope"}
+		ev1   = NewScanLine().ResetLine(0, "nope")
 	)
 
 	b.ReportAllocs()
@@ -100,7 +100,7 @@ func BenchmarkSingleHit(b *testing.B) {
 
 	var (
 		clock int64
-		ev1   = LogEntry{Line: "Bring me a shrubbery"}
+		ev1   = NewScanLine().ResetLine(0, "Bring me a shrubbery")
 	)
 
 	b.ReportAllocs()

--- a/pkg/scanner/match.go
+++ b/pkg/scanner/match.go
@@ -72,7 +72,7 @@ func (sr *MatchScan) Bind() ScanFuncT {
 			}
 		}
 
-		sz := entry.Size()
+		sz := entry.UpperBound()
 		if sr.sz += sz; sr.sz > sr.maxSz {
 			sr.clip = true
 			sr.sz -= sz

--- a/pkg/scanner/stdread.go
+++ b/pkg/scanner/stdread.go
@@ -17,7 +17,7 @@ func NewStdReadScan(maxSz int) *StdReadScan {
 }
 
 func (sr *StdReadScan) Scan(entry LogEntry) bool {
-	sz := entry.Size()
+	sz := entry.UpperBound()
 	if sr.sz += sz; sr.sz > sr.maxSz {
 		sr.clip = true
 		sr.sz -= sz


### PR DESCRIPTION
Previous implement only cached within a single matcher. Change allows the cache to be shared across matchers for each line. This is particularly useful for the JQ matchers, which need to decode the line as JSON or YAML before matching.

This is a breaking API change.