### PR TITLE
Fix issue where a negate term with the same

### DIFF
--- a/pkg/match/inverse.go
+++ b/pkg/match/inverse.go
@@ -95,6 +95,13 @@ func calcGCWindow(window int64, resets []resetT) (int64, int64) {
 		}
 	}
 
+	// If we have zero window and no slide on reset, adjust gcLeft to 1.
+	// This ensures that we keep reset terms with same timestamp as the anchor term
+	// around for one more tick in case it is followed by a match with the same timestamp.
+	if window == 0 && len(resets) > 0 && left == 0 {
+		return 1, right
+	}
+
 	return (-1 * left), right
 }
 

--- a/pkg/match/inverse_seq_test.go
+++ b/pkg/match/inverse_seq_test.go
@@ -500,6 +500,26 @@ func NewCasesSeqResets() casesT {
 			},
 		},
 
+		"ResetBeforeMatchOnZeroWindow": {
+			// -2--------------- alpha
+			// -1--------------- reset
+			// Zero window, but reset should still deny matches with same timestamp, and should not cause errors.
+			window: 0,
+			terms:  []string{"alpha", "beta"},
+			reset: []ResetT{
+				{
+					Term:     makeRaw("reset"),
+					Absolute: true,
+				},
+			},
+			steps: []stepT{
+				{line: "reset", stamp: 1},
+				{line: "alpha", stamp: 1},
+				{line: "beta", stamp: 1},
+				{line: "NOOP"}, // Force eval on alpha, should not fire due to reset on same timestamp
+			},
+		},
+
 		// // Disabled test; non-zero anchors on dupe terms not supported.
 		// "ResetDupesWithAnchorFire": {
 		// 	window: 5,

--- a/pkg/match/inverse_set_test.go
+++ b/pkg/match/inverse_set_test.go
@@ -617,6 +617,24 @@ func NewCasesSetResets() casesT {
 			},
 		},
 
+		"ResetBeforeMatchOnZeroWindow": {
+			// -2--------------- alpha
+			// -1--------------- reset
+			// Zero window, but reset should still deny matches with same timestamp, and should not cause errors.
+			window: 0,
+			terms:  []string{"alpha"},
+			reset: []ResetT{
+				{
+					Term: makeRaw("reset"),
+				},
+			},
+			steps: []stepT{
+				{line: "reset", stamp: 1},
+				{line: "alpha", stamp: 1},
+				{line: "NOOP"}, // Force eval on alpha, should not fire due to reset on same timestamp
+			},
+		},
+
 		// // Disabled test; known logical flaw in inverset set with dupes causes this test to fail.
 		// "ResetDupesWithAnchorMiss": {
 		// 	window: 5,


### PR DESCRIPTION
timestamp with the following term was incorrectly
ignored on a zero window.

Effectively, the garbage collector was firing
prematurely on the reset term.  Adjust the gcLeft
check to account for the derivative matching conditions of a zero window.